### PR TITLE
WorldEdit permissions system support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,34 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>com.sk89q:worldedit</artifact>
+                                     <includes>
+                                        <include>com/sk89q/bukkit/migration/PermissionsProvider.class</include>
+                                    </includes>
+                                </filter>
+                            </filters>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.sk89q:worldedit</include>
+                                </includes>
+                            </artifactSet>
+                    </configuration>
+          </execution>
+        </executions>
+      </plugin>
+            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptors>
@@ -43,6 +71,12 @@
             </plugin>
         </plugins>
     </build>
+    <repositories>
+        <repository>
+        <id>sk89q-mvn2</id>
+        <url>http://mvn2.sk89q.com/repo</url>
+    </repository>
+    </repositories>
     <dependencies>
         <dependency>
             <groupId>org.bukkit</groupId>
@@ -60,6 +94,13 @@
             <groupId>me.taylorkelly.help</groupId>
             <artifactId>Help</artifactId>
             <version>[0.2,)</version>
+            <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sk89q</groupId>
+            <artifactId>worldedit</artifactId>
+            <version>4.7-SNAPSHOT</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>

--- a/src/main/java/ru/tehkode/permissions/bukkit/PermissionsEx.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/PermissionsEx.java
@@ -40,12 +40,13 @@ import ru.tehkode.permissions.bukkit.commands.*;
 import ru.tehkode.permissions.bukkit.modifyworld.ModifyworldManager;
 import ru.tehkode.permissions.commands.CommandsManager;
 import ru.tehkode.permissions.config.Configuration;
+import com.sk89q.bukkit.migration.PermissionsProvider;
 
 /**
  *
  * @author code
  */
-public class PermissionsEx extends JavaPlugin {
+public class PermissionsEx extends JavaPlugin implements PermissionsProvider {
 
     protected static final String configFile = "config.yml";
     protected static final Logger logger = Logger.getLogger("Minecraft");
@@ -172,6 +173,23 @@ public class PermissionsEx extends JavaPlugin {
             configuration.load();
         }
         return configuration;
+    }
+    
+    // WEPIF
+    public boolean hasPermission(String name, String permission) {
+        return this.permissionsManager.has(getServer().getPlayer(name), permission);
+    }
+    
+    public boolean hasPermission(String world, String name, String permission) {
+        return this.permissionsManager.has(name, permission, world);
+    }
+    
+    public boolean inGroup(String player, String group) {
+        return this.permissionsManager.getUser(player).inGroup(group);
+    }
+    
+    public String[] getGroups(String player) {
+        return this.permissionsManager.getUser(player).getGroupsNames();
     }
 
     public class PlayerEventsListener extends PlayerListener {


### PR DESCRIPTION
This adds support for WorldEdit's permissions system, bringing full PermissionsEx compatibility to all plugins using it. As it adds a method added to the WorldEdit PermissionsProvider interface in 4.7, the WorldEdit dependency is set to 4.7-SNAPSHOT. Once WorldEdit 4.7 is released, the dependency version should be set to the release build (4.7). Note that this does not add a runtime dependency on WorldEdit due to the shading of the interface needed for WEPIF support.

tl;dr: this adds full compatibility with worldedit. pom dep version should be changed to 4.7 once it is released
