### PR TITLE
Adding or removing users requires permissions.managae.membership.<group>

### DIFF
--- a/src/main/java/ru/tehkode/permissions/bukkit/commands/GroupCommands.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/commands/GroupCommands.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import ru.tehkode.permissions.PermissionGroup;
 import ru.tehkode.permissions.PermissionUser;
@@ -475,11 +476,20 @@ public class GroupCommands extends PermissionsCommand {
      */
     @Command(name = "pex",
     syntax = "group <group> users",
-    permission = "permissions.manage.membership",
     description = "List all users in <group>")
     public void groupUsersList(Plugin plugin, CommandSender sender, Map<String, String> args) {
         String groupName = this.autoCompleteGroupName(args.get("group"));
 
+        PermissionUser player = null;
+        if (sender instanceof Player) {
+        	player = PermissionsEx.getPermissionManager().getUser(((Player) sender).getName());
+            
+            if(player == null || !player.has("permissions.manage.membership." + groupName)){
+                sender.sendMessage(ChatColor.RED + "You don't have enough permissions manage this group");
+                return;
+            }
+        }
+        
         PermissionUser[] users = PermissionsEx.getPermissionManager().getUsers(groupName);
 
         if (users == null || users.length == 0) {
@@ -495,12 +505,21 @@ public class GroupCommands extends PermissionsCommand {
 
     @Command(name = "pex",
     syntax = "group <group> user add <user> [world]",
-    permission = "permissions.manage.membership",
     description = "Add <user> (single or comma-separated list) to <group>")
     public void groupUsersAdd(Plugin plugin, CommandSender sender, Map<String, String> args) {
         String groupName = this.autoCompleteGroupName(args.get("group"));
         String worldName = this.autoCompleteWorldName(args.get("world"));
 
+        PermissionUser player = null;
+        if (sender instanceof Player) {
+        	player = PermissionsEx.getPermissionManager().getUser(((Player) sender).getName());
+            
+            if(player == null || !player.has("permissions.manage.membership." + groupName)){
+                sender.sendMessage(ChatColor.RED + "You don't have enough permissions manage this group");
+                return;
+            }
+        }
+        
         String users[];
 
         if (!args.get("user").contains(",")) {
@@ -527,12 +546,21 @@ public class GroupCommands extends PermissionsCommand {
 
     @Command(name = "pex",
     syntax = "group <group> user remove <user> [world]",
-    permission = "permissions.manage.membership",
     description = "Add <user> (single or comma-separated list) to <group>")
     public void groupUsersRemove(Plugin plugin, CommandSender sender, Map<String, String> args) {
         String groupName = this.autoCompleteGroupName(args.get("group"));
         String worldName = this.autoCompleteWorldName(args.get("world"));
 
+        PermissionUser player = null;
+        if (sender instanceof Player) {
+        	player = PermissionsEx.getPermissionManager().getUser(((Player) sender).getName());
+            
+            if(player == null || !player.has("permissions.manage.membership." + groupName)){
+                sender.sendMessage(ChatColor.RED + "You don't have enough permissions manage this group");
+                return;
+            }
+        }
+        
         String users[];
 
         if (!args.get("user").contains(",")) {

--- a/src/main/java/ru/tehkode/permissions/bukkit/commands/UserCommands.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/commands/UserCommands.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import ru.tehkode.permissions.PermissionGroup;
 import ru.tehkode.permissions.PermissionManager;
@@ -377,13 +378,22 @@ public class UserCommands extends PermissionsCommand {
 
     @Command(name = "pex",
     syntax = "user <user> group add <group> [world]",
-    permission = "permissions.manage.membership",
     description = "Add <user> to <group>")
     public void userAddGroup(Plugin plugin, CommandSender sender, Map<String, String> args) {
         String userName = this.autoCompletePlayerName(args.get("user"));
         String groupName = this.autoCompleteGroupName(args.get("group"));
         String worldName = this.autoCompleteWorldName(args.get("world"));
 
+        PermissionUser player = null;
+        if (sender instanceof Player) {
+        	player = PermissionsEx.getPermissionManager().getUser(((Player) sender).getName());
+            
+            if(player == null || !player.has("permissions.manage.membership." + groupName)){
+                sender.sendMessage(ChatColor.RED + "You don't have enough permissions manage this group");
+                return;
+            }
+        }
+        
         PermissionUser user = PermissionsEx.getPermissionManager().getUser(userName);
 
         if (user == null) {
@@ -438,13 +448,22 @@ public class UserCommands extends PermissionsCommand {
 
     @Command(name = "pex",
     syntax = "user <user> group remove <group> [world]",
-    permission = "permissions.manage.membership",
     description = "Remove <user> from <group>")
     public void userRemoveGroup(Plugin plugin, CommandSender sender, Map<String, String> args) {
         String userName = this.autoCompletePlayerName(args.get("user"));
         String groupName = this.autoCompleteGroupName(args.get("group"));
         String worldName = this.autoCompleteWorldName(args.get("world"));
 
+        PermissionUser player = null;
+        if (sender instanceof Player) {
+        	player = PermissionsEx.getPermissionManager().getUser(((Player) sender).getName());
+            
+            if(player == null || !player.has("permissions.manage.membership." + groupName)){
+                sender.sendMessage(ChatColor.RED + "You don't have enough permissions manage this group");
+                return;
+            }
+        }
+        
         PermissionUser user = PermissionsEx.getPermissionManager().getUser(userName);
 
         if (user == null) {


### PR DESCRIPTION
Adding or removing users from a group either via "user <user> group (add|remove) <group>" or "group <group> user (add|remove) <user>" requires that user to have the permission permissions.managae.membership.<group>

Listing users with "group <group> users" requires that user to have the permission permissions.managae.membership.<group>
