### PR TITLE
Call priority of PLAYER_JOIN events lowered

### DIFF
--- a/src/main/java/ru/tehkode/permissions/bukkit/BukkitPermissions.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/BukkitPermissions.java
@@ -82,8 +82,10 @@ public class BukkitPermissions {
         PluginManager manager = plugin.getServer().getPluginManager();
 
         PlayerEvents playerEventListener = new PlayerEvents();
-
-        manager.registerEvent(Event.Type.PLAYER_JOIN, playerEventListener, Event.Priority.Normal, plugin);
+        
+        // Priority set to Lowest so that plugins can handle the PlayerJoinEvent with updated permissions
+        manager.registerEvent(Event.Type.PLAYER_JOIN, playerEventListener, Event.Priority.Lowest, plugin);
+        
         manager.registerEvent(Event.Type.PLAYER_KICK, playerEventListener, Event.Priority.Normal, plugin);
         manager.registerEvent(Event.Type.PLAYER_QUIT, playerEventListener, Event.Priority.Normal, plugin);
 


### PR DESCRIPTION
Call priority of **_PLAYER_JOIN**_ events lowered from _Normal_ to _Lowest_ in order to let other plugins easily handle theses events with properly updated permissions.
