### PR TITLE
Numerical usernames - workaround

### DIFF
--- a/src/main/java/ru/tehkode/permissions/config/ConfigurationNode.java
+++ b/src/main/java/ru/tehkode/permissions/config/ConfigurationNode.java
@@ -225,11 +225,14 @@ public class ConfigurationNode extends org.bukkit.util.config.ConfigurationNode 
 			Map<String, ConfigurationNode> nodes =
 					new HashMap<String, ConfigurationNode>();
 
-			for (Map.Entry<String, Object> entry : ((Map<String, Object>) o).entrySet()) {
+			for (Map.Entry<Object, Object> entry : ((Map<Object, Object>) o).entrySet()) {
+                                if (!(entry.getKey() instanceof String))
+                                    continue;
+
 				if (entry.getValue() instanceof ConfigurationNode) {
-					nodes.put(entry.getKey(), (ConfigurationNode) entry.getValue());
+					nodes.put((String) entry.getKey(), (ConfigurationNode) entry.getValue());
 				} else if (entry.getValue() instanceof Map) {
-					nodes.put(entry.getKey(), new ConfigurationNode((Map<String, Object>) entry.getValue()));
+					nodes.put((String) entry.getKey(), new ConfigurationNode((Map<String, Object>) entry.getValue()));
 				}
 			}
 


### PR DESCRIPTION
When key isn't string it's dropped/ignored/forgotten! Basically just workaround to keep running, when some keys are integers (Fixed only one place, maybe there are more). So, whole system won't crash because of one wrong record.
