### PR TITLE
Added support for Spout (the server) and Glowstone Permissible injection.

### DIFF
--- a/src/main/java/ru/tehkode/permissions/PermissionManager.java
+++ b/src/main/java/ru/tehkode/permissions/PermissionManager.java
@@ -82,7 +82,7 @@ public class PermissionManager {
     /**
      * Check if player with name has permission in world
      * 
-     * @param player player object
+     * @param playerName player name
      * @param permission permission as string to check against
      * @param world world's name as string
      * @return true on success false otherwise
@@ -380,7 +380,7 @@ public class PermissionManager {
     /**
      * Return array of world names who has world inheritance
      * 
-     * @param world World name
+     * @param worldName World name
      * @return Array of parent world, if world does not exist return empty array
      */
     public String[] getWorldInheritance(String worldName) {
@@ -447,6 +447,11 @@ public class PermissionManager {
             this.backend.reload();
         }
         this.callEvent(PermissionSystemEvent.Action.RELOADED);
+    }
+
+    public void end() {
+        reset();
+        timer.cancel();
     }
 
     protected void clearCache() {

--- a/src/main/java/ru/tehkode/permissions/bukkit/BukkitPermissions.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/BukkitPermissions.java
@@ -28,6 +28,7 @@ import org.bukkit.event.CustomEventListener;
 import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerListener;
+import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.event.server.ServerListener;
 import org.bukkit.permissions.Permission;
@@ -106,7 +107,7 @@ public class BukkitPermissions {
 	private void registerEvents() {
 		PluginManager manager = plugin.getServer().getPluginManager();
 
-		manager.registerEvent(Event.Type.PLAYER_JOIN, new PlayerEvents(), Event.Priority.Low, plugin);
+		manager.registerEvent(Event.Type.PLAYER_LOGIN, new PlayerEvents(), Event.Priority.Lowest, plugin);
 
 		manager.registerEvent(Event.Type.CUSTOM_EVENT, new PEXEvents(), Event.Priority.Low, plugin);
 
@@ -136,7 +137,7 @@ public class BukkitPermissions {
 	protected class PlayerEvents extends PlayerListener {
 
 		@Override
-		public void onPlayerJoin(PlayerJoinEvent event) {
+		public void onPlayerLogin(PlayerLoginEvent event) {
 			updatePermissions(event.getPlayer());
 		}
 	}

--- a/src/main/java/ru/tehkode/permissions/bukkit/PermissionsEx.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/PermissionsEx.java
@@ -109,7 +109,7 @@ public class PermissionsEx extends JavaPlugin {
 	@Override
 	public void onDisable() {
 		if (this.permissionsManager != null) {
-			this.permissionsManager.reset();
+			this.permissionsManager.end();
 		}
 
 		this.getServer().getServicesManager().unregister(PermissionManager.class, this.permissionsManager);

--- a/src/main/java/ru/tehkode/permissions/bukkit/superperms/PermissibleInjector.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/superperms/PermissibleInjector.java
@@ -1,0 +1,99 @@
+package ru.tehkode.permissions.bukkit.superperms;
+
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.Permissible;
+import org.bukkit.permissions.PermissibleBase;
+
+import java.lang.reflect.Field;
+import java.util.logging.Logger;
+
+/**
+ * This class handles injection of {@link Permissible}s into {@link Player}s for various server implementations.
+ */
+public abstract class PermissibleInjector {
+	protected final String clazzName, fieldName;
+	protected final boolean copyValues;
+
+	public PermissibleInjector(String clazzName, String fieldName, boolean copyValues) {
+		this.clazzName = clazzName;
+		this.fieldName = fieldName;
+		this.copyValues = copyValues;
+	}
+
+	/**
+	 * Attempts to inject {@code permissible} into {@code player},
+	 * @param player The player to have {@code permissible} injected into
+	 * @param permissible The permissible to inject into {@code player}
+	 * @return whether the injection was successful
+	 * @throws NoSuchFieldException when the permissions field could not be found in the Permissible
+	 * @throws IllegalAccessException when things go very wrong
+	 */
+	public boolean inject(Player player, Permissible permissible) throws NoSuchFieldException, IllegalAccessException {
+		Class humanEntity;
+		try {
+			humanEntity = Class.forName(clazzName);
+		} catch (ClassNotFoundException e) {
+			Logger.getLogger("Minecraft").warning("[PermissionsEx] Unknown server implementation being used!");
+			return false;
+		}
+
+		if (!humanEntity.isAssignableFrom(player.getClass())) {
+			Logger.getLogger("Minecraft").warning("[PermissionsEx] Strange error while injecting permissible!");
+			return false;
+		}
+
+		Field permField = humanEntity.getDeclaredField(fieldName);
+		// Make it public for reflection
+		permField.setAccessible(true);
+
+		if (copyValues) {
+			PermissibleBase oldBase = (PermissibleBase) permField.get(player);
+
+			// Copy permissions and attachments from old Permissible
+
+			// Attachments
+			Field attachmentField = PermissibleBase.class.getDeclaredField("attachments");
+			attachmentField.setAccessible(true);
+			attachmentField.set(permissible, attachmentField.get(oldBase));
+
+			// Permissions
+			Field permissionsField = PermissibleBase.class.getDeclaredField("permissions");
+			permissionsField.setAccessible(true);
+			permissionsField.set(permissible, permissionsField.get(oldBase));
+		}
+
+		// Inject permissible
+		permField.set(player, permissible);
+		return true;
+	}
+
+	public abstract boolean isApplicable(Player player);
+
+	public static class ServerNamePermissibleInjector extends PermissibleInjector {
+		protected final String serverName;
+
+		public ServerNamePermissibleInjector(String clazz, String field, boolean copyValues, String serverName) {
+			super(clazz, field, copyValues);
+			this.serverName = serverName;
+		}
+
+		@Override
+		public boolean isApplicable(Player player) {
+			return player.getServer().getName().equalsIgnoreCase(serverName);
+		}
+	}
+
+	public static class ClassNameRegexPermissibleInjector extends PermissibleInjector {
+		private final String regex;
+
+		public ClassNameRegexPermissibleInjector(String clazz, String field, boolean copyValues, String regex) {
+			super(clazz, field, copyValues);
+			this.regex = regex;
+		}
+
+		@Override
+		public boolean isApplicable(Player player) {
+			return player.getClass().getName().matches(regex);
+		}
+	}
+}


### PR DESCRIPTION
I also fixed a few other issues I've seen over the past few months:
- Kill the timer thread when disabling the plugin. (Glowstone/Spout won't stop unless all threads are shut down by their owners or complete)
- Made the DinnerPerms event listener inject the PEX permissible as early as possible in the login process. (Whitelisting and such)
- Made permissible injection more flexible to allow for adding additional implementations of Bukkit in the future with little effort.
