### PR TITLE
Fix reseting the entire node, not the specific sub-node

### DIFF
--- a/src/main/java/ru/tehkode/permissions/backends/file/FileEntity.java
+++ b/src/main/java/ru/tehkode/permissions/backends/file/FileEntity.java
@@ -151,9 +151,9 @@ public class FileEntity extends PermissionEntity {
         if (world != null && !world.isEmpty()) {
             nodePath = "worlds.`" + world + "`." + nodePath;
         }
-        
+
+        nodePath += ".`" + permission + "`";        
         if (value != null && !value.isEmpty()) {
-            nodePath += ".`" + permission + "`";
             this.node.setProperty(nodePath, value);
         } else {
             this.node.removeProperty(nodePath);


### PR DESCRIPTION
For example, if you do /pex user mrapple set myoption "" it will erase everything under options, not just myoption.
