### PR TITLE
Add CraftBukkit++ support

### DIFF
--- a/src/main/java/ru/tehkode/permissions/bukkit/superperms/PermissiblePEX.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/superperms/PermissiblePEX.java
@@ -45,7 +45,8 @@ public class PermissiblePEX extends PermissibleBase {
 		new ServerNamePermissibleInjector("net.glowstone.entity.GlowHumanEntity", "permissions", true, "Glowstone"),
 		new ServerNamePermissibleInjector("org.getspout.server.entity.SpoutHumanEntity", "permissions", true, "Spout"),
 		new ClassNameRegexPermissibleInjector("org.getspout.spout.player.SpoutCraftPlayer", "perm", false, "Spout"),
-		new ServerNamePermissibleInjector("org.bukkit.craftbukkit.entity.CraftHumanEntity", "perm", true, "CraftBukkit")
+		new ServerNamePermissibleInjector("org.bukkit.craftbukkit.entity.CraftHumanEntity", "perm", true, "CraftBukkit"),
+		new ServerNamePermissibleInjector("org.bukkit.craftbukkit.entity.CraftHumanEntity", "perm", true, "CraftBukkit++")
 	};
 	protected Player player = null;
 	protected boolean strictMode = false;


### PR DESCRIPTION
CraftBukkit++ is a modified version of CraftBukkit with many performance
tweaks. Because of the changed server name to "CraftBukkit++" PEX does
not work.
