### PR TITLE
Change ordering for SQL permissions to something useful.

### DIFF
--- a/src/main/java/ru/tehkode/permissions/backends/sql/SQLEntity.java
+++ b/src/main/java/ru/tehkode/permissions/backends/sql/SQLEntity.java
@@ -365,7 +365,7 @@ public class SQLEntity extends PermissionEntity {
 		this.commonPermissions = new LinkedList<String>();
 
 		try {
-			ResultSet results = this.db.select("SELECT `permission`, `world`, `value` FROM `permissions` WHERE `name` = ? AND `type` = ? ORDER BY `id` DESC", this.getName(), this.type.ordinal());
+			ResultSet results = this.db.select("SELECT `permission`, `world`, `value` FROM `permissions` WHERE `name` = ? AND `type` = ? ORDER BY `permission`", this.getName(), this.type.ordinal());
 			while (results.next()) {
 				String permission = results.getString("permission").trim();
 				String world = results.getString("world").trim();


### PR DESCRIPTION
Ordering by permission means that all negation nodes and all non-inheriting nodes are checked first for an entity. This is what every single user needs. There is not a single use for permissions being checked in order of insertion.

Example order returned:
# -permission
# permission

-permission
permission

Additionally, this precludes the need to order the result because the ordering is already present in the existing index `unique`. Ordering by id is therefore slower than ordering by permission. An EXPLAIN SELECT query will demonstrate this.
