### PR TITLE
Don't trim permissions->value in SQLBackend 

### DIFF
--- a/src/main/java/ru/tehkode/permissions/backends/sql/SQLEntity.java
+++ b/src/main/java/ru/tehkode/permissions/backends/sql/SQLEntity.java
@@ -369,7 +369,7 @@ public class SQLEntity extends PermissionEntity {
 			while (results.next()) {
 				String permission = results.getString("permission").trim();
 				String world = results.getString("world").trim();
-				String value = results.getString("value").trim();
+				String value = results.getString("value");
 
 				// @TODO: to this in more optimal way
 				if (value.isEmpty()) {


### PR DESCRIPTION
The value-field also stores the per-world-prefix.
Trimming it causes e.g. "[Player]Marco01809" instead of "[Player] Marco01809".

Signed-off-by: Jan Erik Petersen Marco01_809@web.de
