### PR TITLE
Fixed child permissions bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.4.6-R0.1-SNAPSHOT</version>
+            <version>1.4.7-R1.1-SNAPSHOT</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/src/main/java/ru/tehkode/permissions/PermissionUser.java
+++ b/src/main/java/ru/tehkode/permissions/PermissionUser.java
@@ -20,6 +20,7 @@ package ru.tehkode.permissions;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.permissions.Permission;
 import ru.tehkode.permissions.events.PermissionEntityEvent;
 import ru.tehkode.permissions.exceptions.RankingException;
 
@@ -737,7 +738,40 @@ public abstract class PermissionUser extends PermissionEntity {
 				parentGroup.getInheritedPermissions(worldName, permissions, true, false, true);
 			}
 		}
+        
+        // Add all child nodes
+        for (String node : permissions.toArray(new String[0])){
+            this.getInheritedChildPermissions(node, permissions);
+        }
 	}
+    
+    protected void getInheritedChildPermissions(String perm, List<String> list)
+    {
+        getInheritedChildPermissions(perm, list, false);
+    }
+    
+    protected void getInheritedChildPermissions(String perm, List<String> list, boolean invert) {
+        
+        if (perm.startsWith("-")) {
+            invert = !invert;
+            perm = perm.substring(1);
+        }
+        getInheritedChildPermissions(Bukkit.getPluginManager().getPermission(perm), list, invert);
+    }
+    
+    protected void getInheritedChildPermissions(Permission perm, List<String> list, boolean invert) {
+        if (perm == null) {
+            return;
+        }
+        for (Map.Entry<String, Boolean> entry : perm.getChildren().entrySet()){
+            boolean has = entry.getValue().booleanValue() ^ invert;
+            String node = (has ? "" : "-") + entry.getKey();
+            if (!list.contains(node)){
+                list.add(node);
+                getInheritedChildPermissions(node, list, !has);
+            }
+        }
+    }
 
 	@Override
 	public void addTimedPermission(String permission, String world, int lifeTime) {


### PR DESCRIPTION
Fixed the bug that, when a permission with child permission is given to a player or group, the players would only get the parent, but not the child permissions.
