### PR TITLE
Update DateUtils.java to use HashMap instead of long if-else-chain

### DIFF
--- a/src/main/java/ru/tehkode/utils/DateUtils.java
+++ b/src/main/java/ru/tehkode/utils/DateUtils.java
@@ -6,6 +6,18 @@ import java.util.regex.Pattern;
 public class DateUtils {
 	protected final static Pattern INTERVAL_PATTERN = Pattern.compile("((?:\\d+)|(?:\\d+\\.\\d+))\\s*(second|minute|hour|day|week|month|year|s|m|h|d|w)", Pattern.CASE_INSENSITIVE);
 
+	static Map<String,Integer> secondsMap;
+	{
+	    Map<String,Integer> temp = new HashMap<String, Integer>();
+	    temp.put("second",1);	temp.put("s",1);
+	    temp.put("minute",60);	temp.put("m",60);
+	    temp.put("hour",3600);	temp.put("h",3600);
+	    temp.put("day",86400);	temp.put("d",86400);
+	    temp.put("week",604800);	temp.put("w",604800);
+	    temp.put("month",2592000);
+	    temp.put("year",31104000);
+	    secondsMap = Collections.unmodifiableMap(temp);
+	}
 
 	public static int parseInterval(String arg) {
 		if (arg.matches("^\\d+$")) {
@@ -26,22 +38,10 @@ public class DateUtils {
 	public static int getSecondsIn(String type) {
 		type = type.toLowerCase();
 
-		if ("second".equals(type) || "s".equals(type)) {
-			return 1;
-		} else if ("minute".equals(type) || "m".equals(type)) {
-			return 60;
-		} else if ("hour".equals(type) || "h".equals(type)) {
-			return 3600;
-		} else if ("day".equals(type) || "d".equals(type)) {
-			return 86400;
-		} else if ("week".equals(type) || "w".equals(type)) {
-			return 604800;
-		} else if ("month".equals(type)) {
-			return 2592000;
-		} else if ("year".equals(type)) {
-			return 31104000;
+		if (secondsMap.containsKey(type)) {
+			return secondsMap.get(type);
+		} else {
+			return 0;
 		}
-
-		return 0;
 	}
 }


### PR DESCRIPTION
This pull request changes DateUtils.java so that it uses a HashMap to store the relationship between the type parameter and the resulting getSecondsIn().
