### PR TITLE
adding IntervalType enum instead of long if-else chain

### DIFF
--- a/src/main/java/ru/tehkode/utils/DateUtils.java
+++ b/src/main/java/ru/tehkode/utils/DateUtils.java
@@ -26,22 +26,6 @@ public class DateUtils {
 	public static int getSecondsIn(String type) {
 		type = type.toLowerCase();
 
-		if ("second".equals(type) || "s".equals(type)) {
-			return 1;
-		} else if ("minute".equals(type) || "m".equals(type)) {
-			return 60;
-		} else if ("hour".equals(type) || "h".equals(type)) {
-			return 3600;
-		} else if ("day".equals(type) || "d".equals(type)) {
-			return 86400;
-		} else if ("week".equals(type) || "w".equals(type)) {
-			return 604800;
-		} else if ("month".equals(type)) {
-			return 2592000;
-		} else if ("year".equals(type)) {
-			return 31104000;
-		}
-
-		return 0;
-	}
+		return Interval.byLabel(type).value();
+    }
 }

--- a/src/main/java/ru/tehkode/utils/Interval.java
+++ b/src/main/java/ru/tehkode/utils/Interval.java
@@ -1,0 +1,52 @@
+package ru.tehkode.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum Interval {
+    UNKNOWN(0),
+    SECOND(1, "second", "s"),
+    MINUTE(60, "minute", "m"),
+    HOUR(3600, "hour", "h"),
+    DAY(86400, "day", "d"),
+    WEEK(604800, "week", "w"),
+    MONTH(2592000, "month"),
+    YEAR(31104000, "year");
+
+    private final int value;
+
+    private final String[] labels;
+
+    private Interval(int seconds, String... labels) {
+        // save into private final properties
+        this.value = seconds;
+        this.labels = labels;
+    }
+
+    public int value() {
+        return this.value;
+    }
+
+    public String[] labels() {
+        return this.labels;
+    }
+
+    public static Interval byLabel(String label) {
+        if(intervalMap.containsKey(label)) {
+            return intervalMap.get(label);
+        } else {
+            return UNKNOWN;
+        }
+    }
+
+    private final static Map<String, Interval> intervalMap = new HashMap<String, Interval>();
+
+    static {
+        for(Interval type : Interval.values()) {
+            for(String label : type.labels()) {
+                intervalMap.put(label, type);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This PR implements the suggested enum structure to replace the long if-else chain that was used to identify interval lengths. All the DateUtil tests are passing with this and it builds fine.
