### PR TITLE
user's group order

### DIFF
--- a/src/main/java/ru/tehkode/permissions/PermissionManager.java
+++ b/src/main/java/ru/tehkode/permissions/PermissionManager.java
@@ -622,4 +622,18 @@ public class PermissionManager {
 	public Collection<String> getGroupNames() {
 		return backend.getRegisteredGroupNames();
 	}
+	
+	public String[] getGroupUsers(String groupName) {
+		PermissionGroup group = this.getGroup(groupName);
+		List<String> res = new LinkedList<String>();
+		PermissionUser[] users = group.getUsers(groupName);
+		for (PermissionUser user : users) {
+			res.add(user.getName());
+		}
+		String[] array = new String[res.size()];
+		for (int i = 0; i < res.size(); i++) {
+		    array[i] = res.get(i); // Watch out for NullPointerExceptions!
+		}
+		return array;
+	}
 }

--- a/src/main/java/ru/tehkode/permissions/PermissionUser.java
+++ b/src/main/java/ru/tehkode/permissions/PermissionUser.java
@@ -264,7 +264,14 @@ public abstract class PermissionUser extends PermissionEntity {
 			Collections.sort(groups);
 		}
 
-		return groups;
+		List<PermissionGroup> groupsInOrder = new LinkedList<PermissionGroup>();
+		PermissionGroup[] allGroups = this.manager.getGroups();
+		for (PermissionGroup group : allGroups) {
+			if (groups.contains(group)) {
+				groupsInOrder.add(group);
+			}
+		}
+		return groupsInOrder;
 	}
 
 	public Map<String, PermissionGroup[]> getAllGroups() {


### PR DESCRIPTION
Hi,

I have added 2 very-simple features:

One function in PermissionManager to get all groups for one user.
I have made this because JSONAPI do this with a very dirty way (get all player.dat -> get the group for each of them)

I have ordered user's groups with the same order as in the file. This is a workaround for this case:
group admin
group vip (inherit player)
group player

my admin can be admin+vip or admin+player but i always want their prefix to be admin. this function use the order of the group in the file
