### PR TITLE
Fixed NullPointer in configuration from McMyAdmin

### DIFF
--- a/src/main/java/ru/tehkode/permissions/PermissionGroup.java
+++ b/src/main/java/ru/tehkode/permissions/PermissionGroup.java
@@ -155,7 +155,7 @@ public class PermissionGroup extends PermissionEntity implements Comparable<Perm
 				return true;
 			}
 
-			if (visitedParents != null && manager.getGroup(parentGroup).isChildOf(group, worldName, visitedParents)) {
+			if (visitedParents != null && manager.getGroup(parentGroup) != null && manager.getGroup(parentGroup).isChildOf(group, worldName, visitedParents)) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Fixed a NullPointer being spammed in Console when using McMyAdmin and a multi-world permission setup.
(Possibly a faulty-configurations-file)
