### PR TITLE
Fix NetEvents compatibility

### DIFF
--- a/src/main/java/ru/tehkode/permissions/PermissionManager.java
+++ b/src/main/java/ru/tehkode/permissions/PermissionManager.java
@@ -641,6 +641,15 @@ public class PermissionManager {
 	/**
 	 * Reset all in-memory groups and users, clean up runtime stuff, reloads backend
 	 */
+	public void reset() throws PermissionBackendException {
+		reset(true);
+	}
+
+	/**
+	 * Reset all in-memory groups and users, clean up runtime stuff, reloads backend
+	 *
+	 * @param callEvent Call the reload event
+	 */
 	public void reset(boolean callEvent) throws PermissionBackendException {
 		this.clearCache();
 
@@ -656,7 +665,7 @@ public class PermissionManager {
 				this.backend.close();
 				this.backend = null;
 			}
-			reset(true);
+			reset();
 		} catch (PermissionBackendException ignore) {
 			// Ignore because we're shutting down so who cares
 		}

--- a/src/main/java/ru/tehkode/permissions/bukkit/RemoteEventListener.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/RemoteEventListener.java
@@ -71,7 +71,7 @@ public class RemoteEventListener implements Listener {
 					break;
 			}
 		} else if (reloadAll) {
-			manager.reset(true);
+			manager.reset();
 		}
 		} catch (PermissionBackendException e) {
 			e.printStackTrace();

--- a/src/main/java/ru/tehkode/permissions/bukkit/commands/UtilityCommands.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/commands/UtilityCommands.java
@@ -54,7 +54,7 @@ public class UtilityCommands extends PermissionsCommand {
 			description = "Reload environment")
 	public void reload(PermissionsEx plugin, CommandSender sender, Map<String, String> args) {
 		try {
-			plugin.getPermissionsManager().reset(true);
+			plugin.getPermissionsManager().reset();
 			sender.sendMessage(ChatColor.WHITE + "Permissions reloaded");
 		} catch (PermissionBackendException e) {
 			sender.sendMessage(ChatColor.RED + "Failed to reload permissions! Check configuration!\n" +


### PR DESCRIPTION
Some fixes for NetEvents compatibility.
1. If typed _/pex reload_ while using NetEvents, it created a infinite loop of requests between two or more servers (http://puu.sh/bC2Q1/f9222af341.png)
2. If typed  e.g. _/pex group Guest add some.perm_ (note: the capital 'G') other servers would execute `resetGroup("Guest")` instead of `resetGroup("guest")`

I added the argument `boolean callEvent` to `PermissionManager.reset` and changed all occurrences of `reset()`. I could also add a proxy function `reset()`, which calls `reset(true)`, if preferred.
