### PR TITLE
Fix UUID storing

### DIFF
--- a/src/main/java/ru/tehkode/permissions/PermissionManager.java
+++ b/src/main/java/ru/tehkode/permissions/PermissionManager.java
@@ -238,6 +238,7 @@ public class PermissionManager {
 			user = new PermissionUser(identifier, data, this);
 			user.initialize();
 			if (store) {
+				user.getData().save();
 				PermissionUser newUser = this.users.put(identifier, user);
 				if (newUser != null) {
 					user = newUser;


### PR DESCRIPTION
If a player joins a server for the first time while a plugin calls `PermissionsEx.getUser(String playerName)`, the player gets stored with his Username (offline).