### PR TITLE
Fixes NullPointerException when calling isOnline()

### DIFF
--- a/src/main/java/ru/tehkode/permissions/bukkit/PermissionsEx.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/PermissionsEx.java
@@ -365,7 +365,8 @@ public class PermissionsEx extends JavaPlugin implements NativeInterface {
 
 	@Override
 	public boolean isOnline(UUID uuid) {
-		return getServer().getPlayer(uuid).isOnline();
+		Player player = getServer().getPlayer(uuid);
+		return (player != null && player.isOnline());
 	}
 
 	@Override


### PR DESCRIPTION
New issue appeared in last commit. isOnline() throws NullPointerException when player is not online.