### PR TITLE
Fix spongepowered repository url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -271,8 +271,15 @@
       <url>http://pex-repo.aoeu.xyz</url>
     </repository>
     <repository>
-      <id>sponge-repo</id>
+      <id>sponge-maven-repo</id>
+      <name>Sponge maven repo</name>
       <url>http://repo.spongepowered.org/maven</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
     </repository>
     <repository>
       <id>sonatype-snapshots</id>

--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
     </repository>
     <repository>
       <id>sponge-repo</id>
-      <url>https://repo.spongepowered.org/maven</url>
+      <url>http://repo.spongepowered.org/maven</url>
     </repository>
     <repository>
       <id>sonatype-snapshots</id>


### PR DESCRIPTION
spongepowered.org repo is currently accessed through https. The result is that you can't compile pex with maven without adding the certificate with keytool first which is unnessesary since the documentation recommends using http.

See: https://github.com/SpongePowered/SpongeDocs/blob/master/source/workspace/artifact.rst