### PR TITLE
Fix/promote demote respect config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <dependency>
             <groupId>com.zachsthings</groupId>
             <artifactId>netevents</artifactId>
-            <version>1.0</version>
+            <version>1.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/ru/tehkode/permissions/PermissionGroup.java
+++ b/src/main/java/ru/tehkode/permissions/PermissionGroup.java
@@ -108,7 +108,7 @@ public class PermissionGroup extends PermissionEntity implements Comparable<Perm
 	 * @return Name of rank ladder as String
 	 */
 	public String getRankLadder() {
-		return this.getOwnOption("rank-ladder", "", "default");
+		return this.getOwnOption("rank-ladder", null, "default");
 	}
 
 	/**

--- a/src/main/java/ru/tehkode/permissions/PermissionUser.java
+++ b/src/main/java/ru/tehkode/permissions/PermissionUser.java
@@ -19,6 +19,7 @@
 package ru.tehkode.permissions;
 
 import com.google.common.collect.Maps;
+import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import ru.tehkode.permissions.events.PermissionEntityEvent;
@@ -487,10 +488,15 @@ public class PermissionUser extends PermissionEntity {
 	}
 
 	protected void swapGroups(PermissionGroup src, PermissionGroup dst) {
-		List<PermissionGroup> groups = new ArrayList<>(this.getParents());
+		Validate.notNull(src);
+		Validate.notNull(dst);
 
-		groups.remove(src);
-		groups.add(dst);
+		List<PermissionGroup> groups = new ArrayList<>(this.getParents());
+		int indexOfSrcGroup = groups.indexOf(src);
+
+		Validate.isTrue(indexOfSrcGroup != -1);
+
+		groups.set(indexOfSrcGroup, dst);
 
 		this.setParents(groups);
 	}


### PR DESCRIPTION
The promote/demote command use `swapGroup` internally, but it does not respect the config `userAddGroupsLast`.

This should fix it.
I will update the description after it's tested on my server.