### PR TITLE
Don't attempt to fetch UUIDs for inputs longer than 16 characters.

### DIFF
--- a/src/main/java/ru/tehkode/permissions/bukkit/commands/PermissionsCommand.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/commands/PermissionsCommand.java
@@ -83,6 +83,10 @@ public abstract class PermissionsCommand implements CommandListener {
 	}
 
 	private String nameToUUID(String name) {
+		if (name.length() > 16) { // No point in trying to fetch UUID if it is not a valid username.
+			return name;
+		}
+
 		OfflinePlayer player = Bukkit.getServer().getOfflinePlayer(name);
 		if (player != null) {
 			UUID uid = player.getUniqueId();
@@ -100,6 +104,10 @@ public abstract class PermissionsCommand implements CommandListener {
 
 		if (playerName.startsWith("#")) {
 			return nameToUUID(playerName.substring(1));
+		}
+
+		if (playerName.length() > 16) { // No point in trying to auto-complete an invalid username or a UUID.
+			return playerName;
 		}
 
 		List<String> players = new LinkedList<>();


### PR DESCRIPTION
``` java
/pex user {playername}
```

If the input for playername is longer than 16 characters, that means either an invalid name was entered, or the input is already a UUID. In this case, the plugin should not still attempt to fetch the UUID from the playerdata as it will not find anything anyway, and it should not try to auto-complete a UUID.

Currently, the plugin has some weird behavior when a UUID is entered of a player that has recently changed their name, but has not logged in yet to the server where the command is executed on. This is especially problematic for servers that run on BungeeCord + MySQL.

This pull request should fix those problems.
