### PR TITLE
autoCompletePlayerName() returned failed match name strings

### DIFF
--- a/src/main/java/ru/tehkode/permissions/bukkit/commands/GroupCommands.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/commands/GroupCommands.java
@@ -609,13 +609,13 @@ public class GroupCommands extends PermissionsCommand {
 
 		for (String userName : users) {
 			userName = this.autoCompletePlayerName(userName);
-			PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
-			if (user == null) {
-				sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+			if (userName == null) {
+				sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 				return;
 			}
-
+                        
+			PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 			user.addGroup(groupName, worldName);
 
 			sender.sendMessage(ChatColor.WHITE + "User " + user.getName() + " added to " + groupName + " !");
@@ -641,13 +641,13 @@ public class GroupCommands extends PermissionsCommand {
 
 		for (String userName : users) {
 			userName = this.autoCompletePlayerName(userName);
-			PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
-			if (user == null) {
-				sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+			if (userName == null) {
+				sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 				return;
 			}
-
+                        
+			PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 			user.removeGroup(groupName, worldName);
 
 			sender.sendMessage(ChatColor.WHITE + "User " + user.getName() + " removed from " + args.get("group") + " !");

--- a/src/main/java/ru/tehkode/permissions/bukkit/commands/PermissionsCommand.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/commands/PermissionsCommand.java
@@ -135,8 +135,8 @@ public abstract class PermissionsCommand implements CommandListener {
 			return players.get(0);
 		}
 
-		// Nothing found
-		return playerName;
+		// Nothing found and so you should not be returning the same string..... catch the null returning to the cmd
+		return null;
 	}
 
 	protected String describeUser(PermissionUser user) {

--- a/src/main/java/ru/tehkode/permissions/bukkit/commands/PromotionCommands.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/commands/PromotionCommands.java
@@ -75,13 +75,13 @@ public class PromotionCommands extends PermissionsCommand {
 			isPrimary = true)
 	public void promoteUser(PermissionsEx plugin, CommandSender sender, Map<String, String> args) {
 		String userName = this.autoCompletePlayerName(args.get("user"));
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
-		if (user == null) {
-			sender.sendMessage("Specified user \"" + args.get("user") + "\" not found!");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
-
+                
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 		String promoterName = "console";
 		String ladder = "default";
 
@@ -118,13 +118,13 @@ public class PromotionCommands extends PermissionsCommand {
 			isPrimary = true)
 	public void demoteUser(PermissionsEx plugin, CommandSender sender, Map<String, String> args) {
 		String userName = this.autoCompletePlayerName(args.get("user"));
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "Specified user \"" + args.get("user") + "\" not found!");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
-
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
+                
 		String demoterName = "console";
 		String ladder = "default";
 

--- a/src/main/java/ru/tehkode/permissions/bukkit/commands/UserCommands.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/commands/UserCommands.java
@@ -80,12 +80,12 @@ public class UserCommands extends PermissionsCommand {
 		String userName = this.autoCompletePlayerName(args.get("user"));
 		String worldName = this.autoCompleteWorldName(args.get("world"));
 
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
+                
+                PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 		userName = user.getName();
 
 		sender.sendMessage("'" + describeUser(user) + "' is a member of:");
@@ -119,13 +119,12 @@ public class UserCommands extends PermissionsCommand {
 		String userName = this.autoCompletePlayerName(args.get("user"));
 		String worldName = this.autoCompleteWorldName(args.get("world"));
 
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
 
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 		sender.sendMessage(user.getName() + "'s permissions:");
 
 		for (String permission : user.getPermissions(worldName)) {
@@ -141,6 +140,11 @@ public class UserCommands extends PermissionsCommand {
 	public void userListSuperPermissions(PermissionsEx plugin, CommandSender sender, Map<String, String> args) {
 		String userName = this.autoCompletePlayerName(args.get("user"));
 
+                if (userName == null) {
+                    sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
+                    return;
+		}
+                
 		Player player;
 		try {
 			UUID uid = UUID.fromString(userName);
@@ -175,14 +179,14 @@ public class UserCommands extends PermissionsCommand {
 		String userName = this.autoCompletePlayerName(args.get("user"));
 		String worldName = this.autoCompleteWorldName(args.get("world"));
 
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
-
-		if (args.containsKey("newprefix")) {
+                
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
+		
+                if (args.containsKey("newprefix")) {
 			user.setPrefix(args.get("newprefix"), worldName);
 			sender.sendMessage(describeUser(user) + "'s prefix" + (worldName != null ? " (in world \"" + worldName + "\") " : "") + " has been set to \"" + user.getPrefix() + "\"");
 		} else {
@@ -198,12 +202,12 @@ public class UserCommands extends PermissionsCommand {
 		String userName = this.autoCompletePlayerName(args.get("user"));
 		String worldName = this.autoCompleteWorldName(args.get("world"));
 
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
+                
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
 		if (args.containsKey("newsuffix")) {
 			user.setSuffix(args.get("newsuffix"), worldName);
@@ -220,12 +224,12 @@ public class UserCommands extends PermissionsCommand {
 	public void userToggleDebug(PermissionsEx plugin, CommandSender sender, Map<String, String> args) {
 		String userName = this.autoCompletePlayerName(args.get("user"));
 
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
+                
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
 		user.setDebug(!user.isDebug());
 
@@ -240,12 +244,12 @@ public class UserCommands extends PermissionsCommand {
 		String userName = this.autoCompletePlayerName(args.get("user"));
 		String worldName = this.autoCompleteWorldName(args.get("world"));
 
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
+                
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
 		worldName = this.getSafeWorldName(worldName, user);
 
@@ -266,12 +270,12 @@ public class UserCommands extends PermissionsCommand {
 		String userName = this.autoCompletePlayerName(args.get("user"));
 		String worldName = this.autoCompleteWorldName(args.get("world"));
 
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
+                
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
 		worldName = this.getSafeWorldName(worldName, user);
 
@@ -286,12 +290,13 @@ public class UserCommands extends PermissionsCommand {
 			description = "Remove <user>")
 	public void userDelete(PermissionsEx plugin, CommandSender sender, Map<String, String> args) {
 		String userName = this.autoCompletePlayerName(args.get("user"));
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
+                
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
 		if (user.isVirtual()) {
 			sender.sendMessage(ChatColor.RED + "User \"" + describeUser(user) + "\" is virtual.");
@@ -312,12 +317,12 @@ public class UserCommands extends PermissionsCommand {
 		String userName = this.autoCompletePlayerName(args.get("user"));
 		String worldName = this.autoCompleteWorldName(args.get("world"));
 
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
+                
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
 		user.addPermission(args.get("permission"), worldName);
 
@@ -334,12 +339,12 @@ public class UserCommands extends PermissionsCommand {
 		String userName = this.autoCompletePlayerName(args.get("user"));
 		String worldName = this.autoCompleteWorldName(args.get("world"));
 
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
+                
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
 		String permission = this.autoCompletePermission(user, args.get("permission"), worldName);
 
@@ -358,12 +363,12 @@ public class UserCommands extends PermissionsCommand {
 		String userName = this.autoCompletePlayerName(args.get("user"));
 		String worldName = this.autoCompleteWorldName(args.get("world"));
 
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
+                
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
 		List<String> permissions = user.getOwnPermissions(worldName);
 
@@ -392,6 +397,11 @@ public class UserCommands extends PermissionsCommand {
 		String userName = this.autoCompletePlayerName(args.get("user"));
 		String worldName = this.autoCompleteWorldName(args.get("world"));
 
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
+			return;
+		}
+                
 		int lifetime = 0;
 
 		if (args.containsKey("lifetime")) {
@@ -399,16 +409,8 @@ public class UserCommands extends PermissionsCommand {
 		}
 
 		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
-			return;
-		}
-
 		String permission = args.get("permission");
-
 		user.addTimedPermission(permission, worldName, lifetime);
-
 		sender.sendMessage(ChatColor.WHITE + "Timed permission \"" + permission + "\" added!");
 		this.informPlayer(plugin, user, "Your permissions have been changed!");
 
@@ -425,12 +427,12 @@ public class UserCommands extends PermissionsCommand {
 		String worldName = this.autoCompleteWorldName(args.get("world"));
 		String permission = args.get("permission");
 
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
+                
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
 		user.removeTimedPermission(args.get("permission"), worldName);
 
@@ -446,12 +448,12 @@ public class UserCommands extends PermissionsCommand {
 		String userName = this.autoCompletePlayerName(args.get("user"));
 		String worldName = this.autoCompleteWorldName(args.get("world"));
 
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
+                
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
 		user.setOption(args.get("option"), args.get("value"), worldName);
 
@@ -476,12 +478,12 @@ public class UserCommands extends PermissionsCommand {
 		String userName = this.autoCompletePlayerName(args.get("user"));
 		String worldName = this.autoCompleteWorldName(args.get("world"));
 
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
+                
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
 		sender.sendMessage("User \"" + describeUser(user) + "\" @" + worldName + " currently in:");
 		for (PermissionGroup group : user.getParents(worldName)) {
@@ -498,12 +500,12 @@ public class UserCommands extends PermissionsCommand {
 		String groupName = this.autoCompleteGroupName(args.get("group"));
 		String worldName = this.autoCompleteWorldName(args.get("world"));
 
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
+                
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
 		if (args.containsKey("lifetime")) {
 			try {
@@ -567,13 +569,12 @@ public class UserCommands extends PermissionsCommand {
 		String userName = this.autoCompletePlayerName(args.get("user"));
 		String worldName = this.autoCompleteWorldName(args.get("world"));
 
-		PermissionUser user = manager.getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
-
+                
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
 		if (!groups.isEmpty()) {
 			user.setParents(groups, worldName);
@@ -594,12 +595,12 @@ public class UserCommands extends PermissionsCommand {
 		String groupName = this.autoCompleteGroupName(args.get("group"));
 		String worldName = this.autoCompleteWorldName(args.get("world"));
 
-		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+		if (userName == null) {
+			sender.sendMessage(ChatColor.RED + "User does not exist or match any known names.");
 			return;
 		}
+                
+		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
 		user.removeGroup(groupName, worldName);
 


### PR DESCRIPTION
This also fixed the broken null checks for unknown player names
Now commands are returning proper messages again for invalid player names.