### PR TITLE
Sql Support only for users

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.tehkode</groupId>
     <artifactId>PermissionsEx</artifactId>
-    <version>1.23.3-SNAPSHOT</version>
+    <version>1.23.3</version>
     <name>PermissionsEx</name>
     <url>https://github.com/PEXPlugins/PermissionsEx</url>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <dependency>
             <groupId>com.zachsthings</groupId>
             <artifactId>netevents</artifactId>
-            <version>1.0</version>
+            <version>1.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.tehkode</groupId>
     <artifactId>PermissionsEx</artifactId>
-    <version>1.23.2</version>
+    <version>1.23.3-SNAPSHOT</version>
     <name>PermissionsEx</name>
     <url>https://github.com/PEXPlugins/PermissionsEx</url>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.tehkode</groupId>
     <artifactId>PermissionsEx</artifactId>
-    <version>1.23.4-SNAPSHOT</version>
+    <version>1.23.4</version>
     <name>PermissionsEx</name>
     <url>https://github.com/PEXPlugins/PermissionsEx</url>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.8-R0.1-SNAPSHOT</version>
+            <version>1.8.8-R0.1-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.tehkode</groupId>
     <artifactId>PermissionsEx</artifactId>
-    <version>1.23.4</version>
+    <version>1.23.5-SNAPSHOT</version>
     <name>PermissionsEx</name>
     <url>https://github.com/PEXPlugins/PermissionsEx</url>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.tehkode</groupId>
     <artifactId>PermissionsEx</artifactId>
-    <version>1.23.3</version>
+    <version>1.23.4-SNAPSHOT</version>
     <name>PermissionsEx</name>
     <url>https://github.com/PEXPlugins/PermissionsEx</url>
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.tehkode</groupId>
     <artifactId>PermissionsEx</artifactId>
-    <version>1.23.2-SNAPSHOT</version>
+    <version>1.23.2</version>
     <name>PermissionsEx</name>
     <url>https://github.com/PEXPlugins/PermissionsEx</url>
     <properties>

--- a/src/main/java/ru/tehkode/permissions/PermissionGroup.java
+++ b/src/main/java/ru/tehkode/permissions/PermissionGroup.java
@@ -55,7 +55,7 @@ public class PermissionGroup extends PermissionEntity implements Comparable<Perm
 
 	public int getWeight() {
 		if (this.dirtyWeight) {
-			this.weight = this.getOptionInteger("weight", null, 0);
+			this.weight = this.getOwnOptionInteger("weight", null, 0);
 			this.dirtyWeight = false;
 		}
 
@@ -108,7 +108,7 @@ public class PermissionGroup extends PermissionEntity implements Comparable<Perm
 	 * @return Name of rank ladder as String
 	 */
 	public String getRankLadder() {
-		return this.getOption("rank-ladder", "", "default");
+		return this.getOwnOption("rank-ladder", "", "default");
 	}
 
 	/**
@@ -267,6 +267,7 @@ public class PermissionGroup extends PermissionEntity implements Comparable<Perm
 	}
 
 	protected void clearCache() {
+		this.dirtyWeight = true;
 		for (PermissionUser user : this.getActiveUsers()) {
 			user.clearCache();
 		}

--- a/src/main/java/ru/tehkode/permissions/PermissionGroup.java
+++ b/src/main/java/ru/tehkode/permissions/PermissionGroup.java
@@ -108,7 +108,7 @@ public class PermissionGroup extends PermissionEntity implements Comparable<Perm
 	 * @return Name of rank ladder as String
 	 */
 	public String getRankLadder() {
-		return this.getOwnOption("rank-ladder", "", "default");
+		return this.getOwnOption("rank-ladder", null, "default");
 	}
 
 	/**

--- a/src/main/java/ru/tehkode/permissions/PermissionManager.java
+++ b/src/main/java/ru/tehkode/permissions/PermissionManager.java
@@ -720,4 +720,8 @@ public class PermissionManager {
 	public ScheduledExecutorService getExecutor() {
 		return executor;
 	}
+
+	public boolean shouldSaveDefaultGroup() {
+		return config.saveDefaultGroup();
+	}
 }

--- a/src/main/java/ru/tehkode/permissions/PermissionUser.java
+++ b/src/main/java/ru/tehkode/permissions/PermissionUser.java
@@ -59,7 +59,8 @@ public class PermissionUser extends PermissionEntity {
 		super.initialize();
 
 		if (this.manager.shouldCreateUserRecords() && this.isVirtual()) {
-			this.getData().setParents(this.getOwnParentIdentifiers(null), null);
+			List<String> parents = this.manager.shouldSaveDefaultGroup() ? this.getParentIdentifiers(null) : this.getOwnParentIdentifiers(null);
+			this.getData().setParents(parents, null);
 		}
 		updateTimedGroups();
 

--- a/src/main/java/ru/tehkode/permissions/PermissionUser.java
+++ b/src/main/java/ru/tehkode/permissions/PermissionUser.java
@@ -19,6 +19,7 @@
 package ru.tehkode.permissions;
 
 import com.google.common.collect.Maps;
+import org.apache.commons.lang.Validate;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import ru.tehkode.permissions.events.PermissionEntityEvent;
@@ -487,10 +488,15 @@ public class PermissionUser extends PermissionEntity {
 	}
 
 	protected void swapGroups(PermissionGroup src, PermissionGroup dst) {
-		List<PermissionGroup> groups = new ArrayList<>(this.getParents());
+		Validate.notNull(src);
+		Validate.notNull(dst);
 
-		groups.remove(src);
-		groups.add(dst);
+		List<PermissionGroup> groups = new ArrayList<>(this.getParents());
+		int indexOfSrcGroup = groups.indexOf(src);
+
+		Validate.isTrue(indexOfSrcGroup != -1);
+
+		groups.set(indexOfSrcGroup, dst);
 
 		this.setParents(groups);
 	}

--- a/src/main/java/ru/tehkode/permissions/backends/caching/CachingGroupData.java
+++ b/src/main/java/ru/tehkode/permissions/backends/caching/CachingGroupData.java
@@ -3,14 +3,13 @@ package ru.tehkode.permissions.backends.caching;
 import ru.tehkode.permissions.PermissionsGroupData;
 
 import java.util.concurrent.Executor;
-import java.util.concurrent.locks.ReadWriteLock;
 
 /**
  * Cached data for groups
  */
 public class CachingGroupData extends CachingData implements PermissionsGroupData {
 	private final PermissionsGroupData backingData;
-	public CachingGroupData(PermissionsGroupData backingData, Executor executor, ReadWriteLock lock) {
+	public CachingGroupData(PermissionsGroupData backingData, Executor executor, Object lock) {
 		super(executor, lock);
 		this.backingData = backingData;
 	}

--- a/src/main/java/ru/tehkode/permissions/backends/caching/CachingUserData.java
+++ b/src/main/java/ru/tehkode/permissions/backends/caching/CachingUserData.java
@@ -3,14 +3,13 @@ package ru.tehkode.permissions.backends.caching;
 import ru.tehkode.permissions.PermissionsUserData;
 
 import java.util.concurrent.Executor;
-import java.util.concurrent.locks.ReadWriteLock;
 
 /**
  * User data using a cache.
  */
 public class CachingUserData extends CachingData implements PermissionsUserData {
 	private final PermissionsUserData userData;
-	public CachingUserData(PermissionsUserData userData, Executor executor, ReadWriteLock lock) {
+	public CachingUserData(PermissionsUserData userData, Executor executor, Object lock) {
 		super(executor, lock);
 		this.userData = userData;
 	}
@@ -22,7 +21,7 @@ public class CachingUserData extends CachingData implements PermissionsUserData 
 
 	@Override
 	public boolean setIdentifier(final String identifier) {
-		executeWrite(new Runnable() {
+		execute(new Runnable() {
 			@Override
 			public void run() {
 				getBackingData().setIdentifier(identifier);

--- a/src/main/java/ru/tehkode/permissions/backends/file/FileData.java
+++ b/src/main/java/ru/tehkode/permissions/backends/file/FileData.java
@@ -11,47 +11,98 @@ import java.util.logging.Level;
 
 public class FileData implements PermissionsUserData, PermissionsGroupData {
 	protected transient final FileConfig config;
+	private String nodePath, entityName;
+	private final String basePath;
 	private ConfigurationSection node;
 	protected boolean virtual = true;
 	private final String parentPath;
 
-	public FileData(ConfigurationSection node, String parentPath) {
-		this.config = (FileConfig) node.getRoot();
-		this.node = node;
-		this.virtual = node.getParent().getConfigurationSection(node.getName()) == null;
+	public FileData(String basePath, String name, FileConfig config, String parentPath) {
+		this.config = config;
+		this.basePath = basePath;
+		this.node = findNode(name);
 		this.parentPath = parentPath;
 	}
 
-	@Override
-	public String getIdentifier() {
-		return node.getName();
-	}
+	private ConfigurationSection findExistingNode(String entityName, boolean set) {
+		if (config.isLowerCased(basePath)) {
+			entityName = entityName.toLowerCase();
+		}
+		String nodePath = FileBackend.buildPath(basePath, entityName);
 
-	@Override
-	public boolean setIdentifier(String identifier) {
-		String caseCorrectedIdentifier = config.isLowerCased(node.getParent().getCurrentPath()) ? identifier.toLowerCase() : identifier;
-		ConfigurationSection existing = node.getParent().getConfigurationSection(identifier);
-		if (existing == null && config.isLowerCased(node.getParent().getCurrentPath())) {
-			ConfigurationSection users = node.getParent();
+		ConfigurationSection entityNode = this.config.getConfigurationSection(nodePath);
+
+		if (entityNode != null) {
+			this.virtual = false;
+			if (set) {
+				this.nodePath = nodePath;
+				this.entityName = entityName;
+			}
+			return entityNode;
+		}
+
+		if (!config.isLowerCased(basePath)) {
+			ConfigurationSection users = this.config.getConfigurationSection(basePath);
 
 			if (users != null) {
 				for (Map.Entry<String, Object> entry : users.getValues(false).entrySet()) {
-					if (entry.getKey().equalsIgnoreCase(caseCorrectedIdentifier)
+					if (entry.getKey().equalsIgnoreCase(entityName)
 							&& entry.getValue() instanceof ConfigurationSection) {
-						existing = (ConfigurationSection) entry.getValue();
+						if (set) {
+							this.nodePath = FileBackend.buildPath(basePath, entry.getKey());
+							this.entityName = entry.getKey();
+						}
+						return (ConfigurationSection) entry.getValue();
 					}
 				}
 			}
 		}
 
-		if (existing != null) {
+		return null;
+	}
+
+	private ConfigurationSection findNode(String entityName) {
+		if (config.isLowerCased(basePath)) {
+			entityName = entityName.toLowerCase();
+		}
+		ConfigurationSection section = findExistingNode(entityName, true);
+		if (section != null) {
+			return section;
+		}
+
+		// Silly workaround for empty nodes
+		this.nodePath = FileBackend.buildPath(basePath, entityName);
+		section = this.config.createSection(nodePath);
+		this.entityName = entityName;
+		this.config.set(nodePath, null);
+		this.virtual = true; // Make sure
+
+		return section;
+
+	}
+
+	@Override
+	public String getIdentifier() {
+		return entityName;
+	}
+
+	@Override
+	public boolean setIdentifier(String identifier) {
+		ConfigurationSection section = findExistingNode(identifier, false);
+		if (section != null) {
 			return false;
 		}
-		ConfigurationSection oldNode = node;
-		this.node = oldNode.getParent().createSection(caseCorrectedIdentifier, node.getValues(false));
-		oldNode.getParent().set(oldNode.getName(), null);
-		if (this.isVirtual()) {
-			node.getParent().set(node.getName(), null);
+		String caseCorrectedIdentifier = config.isLowerCased(basePath) ? identifier.toLowerCase() : identifier;
+		String oldNodePath = this.nodePath;
+		this.nodePath = FileBackend.buildPath(basePath, caseCorrectedIdentifier);
+		this.node = this.config.createSection(nodePath, node.getValues(false));
+		this.entityName = identifier;
+		this.config.set(oldNodePath, null);
+		if (!this.isVirtual()) {
+			this.config.set(nodePath, node);
+			this.save();
+		} else {
+			this.config.set(nodePath, null);
 		}
 		return true;
 	}
@@ -69,6 +120,7 @@ public class FileData implements PermissionsUserData, PermissionsGroupData {
 	@Override
 	public void setPermissions(List<String> permissions, String worldName) {
 		this.node.set(formatPath(worldName, "permissions"), permissions == null ? null : new ArrayList<>(permissions));
+		save();
 	}
 
 	@Override
@@ -114,6 +166,7 @@ public class FileData implements PermissionsUserData, PermissionsGroupData {
 	@Override
 	public void setOption(String option, String value, String worldName) {
 		this.node.set(formatPath(worldName, "options", option), value);
+		save();
 	}
 
 	@Override
@@ -149,21 +202,21 @@ public class FileData implements PermissionsUserData, PermissionsGroupData {
 	@Override
 	public void save() {
 		if (isVirtual()) {
-			this.node.getParent().set(node.getName(), node);
+			this.config.set(nodePath, node);
 			virtual = false;
 		}
 
 		try {
 			this.config.save();
 		} catch (IOException e) {
-			PermissionsEx.getPermissionManager().getLogger().log(Level.SEVERE, "Error saving data for  " + node.getCurrentPath(), e);
+			PermissionsEx.getPermissionManager().getLogger().log(Level.SEVERE, "Error saving data for  " + nodePath, e);
 		}
 	}
 
 	@Override
 	public void remove() {
-		node.getParent().set(node.getName(), null);
-		this.virtual = true;
+		this.config.set(nodePath, null);
+		this.save();
 	}
 
 	@Override
@@ -181,7 +234,7 @@ public class FileData implements PermissionsUserData, PermissionsGroupData {
 	@Override
 	public List<String> getParents(String worldName) {
 		List<String> parents = this.node.getStringList(formatPath(worldName, parentPath));
-		for (Iterator<String> it = parents.iterator(); it.hasNext(); ) {
+		for (Iterator<String> it = parents.iterator(); it.hasNext();) {
 			final String test = it.next();
 			if (test == null || test.isEmpty()) {
 				it.remove();
@@ -198,6 +251,7 @@ public class FileData implements PermissionsUserData, PermissionsGroupData {
 	@Override
 	public void setParents(List<String> parents, String worldName) {
 		this.node.set(formatPath(worldName, parentPath), parents == null ? null : new ArrayList<>(parents));
+		save();
 	}
 
 	@Override

--- a/src/main/java/ru/tehkode/permissions/backends/sql/SQLBackend.java
+++ b/src/main/java/ru/tehkode/permissions/backends/sql/SQLBackend.java
@@ -48,7 +48,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * @author code
@@ -261,14 +260,14 @@ public class SQLBackend extends PermissionBackend {
 
 	@Override
 	public PermissionsUserData getUserData(String name) {
-		CachingUserData data = new CachingUserData(new SQLData(name, SQLData.Type.USER, this), getExecutor(), new ReentrantReadWriteLock());
+		CachingUserData data = new CachingUserData(new SQLData(name, SQLData.Type.USER, this), getExecutor(), new Object());
 		updateNameCache(userNamesCache, data);
 		return data;
 	}
 
 	@Override
 	public PermissionsGroupData getGroupData(String name) {
-		CachingGroupData data = new CachingGroupData(new SQLData(name, SQLData.Type.GROUP, this), getExecutor(), new ReentrantReadWriteLock());
+		CachingGroupData data = new CachingGroupData(new SQLData(name, SQLData.Type.GROUP, this), getExecutor(), new Object());
 		updateNameCache(groupNamesCache, data);
 		return data;
 	}

--- a/src/main/java/ru/tehkode/permissions/bukkit/ErrorReport.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/ErrorReport.java
@@ -217,8 +217,10 @@ public class ErrorReport {
 		Builder builder = builder(error);
 
 		PermissionsEx pexPlugin = (PermissionsEx) PermissionsEx.getPlugin();
-		builder.addHeading("Basic info").
-				addText("**Server version:** " + Bukkit.getBukkitVersion() + " *running on* " + Bukkit.getVersion());
+		builder.addHeading("Basic info")
+				.addText("**Server version:** " + Bukkit.getBukkitVersion() + " *running on* " + Bukkit.getVersion())
+				.addText("**Online mode:** " + Bukkit.getOnlineMode())
+				.addText("**Java version:** " + Runtime.class.getPackage().getImplementationVendor() + " - " + Runtime.class.getPackage().getImplementationTitle() + " - " + Runtime.class.getPackage().getImplementationVersion());
 
 		if (pexPlugin != null) {
 			Plugin[] plugins = pexPlugin.getServer().getPluginManager().getPlugins();

--- a/src/main/java/ru/tehkode/permissions/bukkit/PermissionsEx.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/PermissionsEx.java
@@ -20,7 +20,6 @@ package ru.tehkode.permissions.bukkit;
 
 import java.lang.reflect.Field;
 import java.util.Calendar;
-import java.util.GregorianCalendar;
 import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -117,7 +116,7 @@ public class PermissionsEx extends JavaPlugin implements NativeInterface {
 
 		public boolean isDay() {
 			final Calendar cal = Calendar.getInstance();
-			return cal.get(GregorianCalendar.MONTH) == Calendar.APRIL && cal.get(GregorianCalendar.DAY_OF_MONTH) == 1;
+			return cal.get(Calendar.MONTH) == Calendar.APRIL && cal.get(Calendar.DAY_OF_MONTH) == 1;
 		}
 
 		@Override

--- a/src/main/java/ru/tehkode/permissions/bukkit/PermissionsExConfig.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/PermissionsExConfig.java
@@ -21,6 +21,7 @@ public class PermissionsExConfig {
 	private final boolean userAddGroupsLast;
 	private final boolean logPlayers;
 	private final boolean createUserRecords;
+	private final boolean saveDefaultGroup;
 	private final String defaultBackend;
 	private final boolean updaterEnabled;
 	private final boolean alwaysUpdate;
@@ -38,6 +39,7 @@ public class PermissionsExConfig {
 		this.userAddGroupsLast = getBoolean("permissions.user-add-groups-last", false);
 		this.logPlayers = getBoolean("permissions.log-players", false);
 		this.createUserRecords = getBoolean("permissions.createUserRecords", false);
+		this.saveDefaultGroup = getBoolean("permissions.save-default-group", false);
 		this.defaultBackend = getString("permissions.backend", PermissionBackend.DEFAULT_BACKEND);
 		this.updaterEnabled = getBoolean("updater", true);
 		this.alwaysUpdate = getBoolean("alwaysUpdate", false);
@@ -98,6 +100,10 @@ public class PermissionsExConfig {
 		return createUserRecords;
 	}
 
+	public boolean saveDefaultGroup() {
+		return saveDefaultGroup;
+	}
+
 	public boolean updaterEnabled() {
 		return updaterEnabled;
 	}
@@ -129,4 +135,5 @@ public class PermissionsExConfig {
 	public void save() {
 		plugin.saveConfig();
 	}
+
 }

--- a/src/main/java/ru/tehkode/permissions/bukkit/SuperpermsListener.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/SuperpermsListener.java
@@ -207,12 +207,18 @@ public class SuperpermsListener implements Listener {
 
 				case PERMISSIONS_CHANGED:
 				case TIMEDPERMISSION_EXPIRED:
+					if (user.isDebug()) {
+						plugin.getLogger().info("Updating superperms permissions for player " + p.getName());
+					}
 					updatePlayerPermission(getCreateWrapper(p, ""), user, p.getWorld().getName());
 					p.recalculatePermissions();
 					break;
 
 				case OPTIONS_CHANGED:
 				case INFO_CHANGED:
+					if (user.isDebug()) {
+						plugin.getLogger().info("Updating superperms metadata for player " + p.getName());
+					}
 					updatePlayerMetadata(getCreateWrapper(p, ".options"), user, p.getWorld().getName());
 					p.recalculatePermissions();
 					break;

--- a/src/main/java/ru/tehkode/permissions/bukkit/commands/PromotionCommands.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/commands/PromotionCommands.java
@@ -157,7 +157,7 @@ public class PromotionCommands extends PermissionsCommand {
 	}
 
 	@Command(name = "promote",
-			syntax = "<user>",
+			syntax = "<user> [ladder]",
 			description = "Promotes <user> to next group",
 			isPrimary = true,
 			permission = "permissions.user.rank.promote")
@@ -166,7 +166,7 @@ public class PromotionCommands extends PermissionsCommand {
 	}
 
 	@Command(name = "demote",
-			syntax = "<user>",
+			syntax = "<user> [ladder]",
 			description = "Demotes <user> to previous group",
 			isPrimary = true,
 			permission = "permissions.user.rank.demote")

--- a/src/main/java/ru/tehkode/permissions/bukkit/commands/UserCommands.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/commands/UserCommands.java
@@ -529,17 +529,7 @@ public class UserCommands extends PermissionsCommand {
 			permission = "",
 			description = "Set <group> for <user>")
 	public void userSetGroup(PermissionsEx plugin, CommandSender sender, Map<String, String> args) {
-		String userName = this.autoCompletePlayerName(args.get("user"));
-		String worldName = this.autoCompleteWorldName(args.get("world"));
-
 		PermissionManager manager = plugin.getPermissionsManager();
-		PermissionUser user = manager.getUser(userName);
-
-		if (user == null) {
-			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
-			return;
-		}
-
 		String groupName = args.get("group");
 
 		List<PermissionGroup> groups;
@@ -573,6 +563,17 @@ public class UserCommands extends PermissionsCommand {
 				return;
 			}
 		}
+
+		String userName = this.autoCompletePlayerName(args.get("user"));
+		String worldName = this.autoCompleteWorldName(args.get("world"));
+
+		PermissionUser user = manager.getUser(userName);
+
+		if (user == null) {
+			sender.sendMessage(ChatColor.RED + "User \"" + userName + "\" doesn't exist.");
+			return;
+		}
+
 
 		if (!groups.isEmpty()) {
 			user.setParents(groups, worldName);

--- a/src/main/java/ru/tehkode/permissions/bukkit/regexperms/PermissiblePEX.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/regexperms/PermissiblePEX.java
@@ -112,13 +112,13 @@ public class PermissiblePEX extends PermissibleBase {
 
 	public boolean isDebug() {
 		boolean debug = plugin.isDebug();
-		try {
+		/*try {
 			PermissionUser user = plugin.getPermissionsManager().getUser(this.player);
 			if (user != null) {
 				debug |= user.isDebug();
 			}
 		} catch (Throwable ignore) {
-		}
+		}*/
 		return debug;
 	}
 

--- a/src/main/java/ru/tehkode/permissions/bukkit/regexperms/PermissionList.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/regexperms/PermissionList.java
@@ -1,6 +1,7 @@
 package ru.tehkode.permissions.bukkit.regexperms;
 
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import org.bukkit.permissions.Permission;
@@ -125,6 +126,6 @@ public class PermissionList extends HashMap<String, Permission> {
 	}
 
 	public Collection<Map.Entry<String, Boolean>> getParents(String permission) {
-		return childParentMapping.get(permission.toLowerCase());
+		return ImmutableSet.copyOf(childParentMapping.get(permission.toLowerCase()));
 	}
 }


### PR DESCRIPTION
Hi guys,
I recently explored a bit the sql option of your pex.
My problem is, that I have 4 different Servers with different plugins and different permissions each group have although the groups are the same on every server and every player has the same group on every server.
I wanted to change my pex so, that not the permissions and groups are saved in to sql but the users only, so that they all will have their group on every server but different permissions according to the server.

It should be pretty obvious I think, because it is so common to have different plugins and different permissions (other playmodes etc.)
Is there an option? 