### PR TITLE
check for permissions to use the command before doing any processing

### DIFF
--- a/src/main/java/ru/tehkode/permissions/bukkit/commands/PromotionCommands.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/commands/PromotionCommands.java
@@ -74,6 +74,18 @@ public class PromotionCommands extends PermissionsCommand {
 			description = "Promotes <user> to next group on [ladder]",
 			isPrimary = true)
 	public void promoteUser(PermissionsEx plugin, CommandSender sender, Map<String, String> args) {
+		
+		PermissionUser promoter = null;
+		if (sender instanceof Player) {
+			promoter = plugin.getPermissionsManager().getUser((Player) sender);
+			if (promoter == null || !promoter.has("permissions.user.promote." + ladder, ((Player) sender).getWorld().getName())) {
+				sender.sendMessage(ChatColor.RED + "You don't have enough permissions to promote on this ladder");
+				return;
+			}
+
+			promoterName = promoter.getName();
+		}
+		
 		String userName = this.autoCompletePlayerName(args.get("user"));
 		PermissionUser user = plugin.getPermissionsManager().getUser(userName);
 
@@ -87,17 +99,6 @@ public class PromotionCommands extends PermissionsCommand {
 
 		if (args.containsKey("ladder")) {
 			ladder = args.get("ladder");
-		}
-
-		PermissionUser promoter = null;
-		if (sender instanceof Player) {
-			promoter = plugin.getPermissionsManager().getUser((Player) sender);
-			if (promoter == null || !promoter.has("permissions.user.promote." + ladder, ((Player) sender).getWorld().getName())) {
-				sender.sendMessage(ChatColor.RED + "You don't have enough permissions to promote on this ladder");
-				return;
-			}
-
-			promoterName = promoter.getName();
 		}
 
 		try {


### PR DESCRIPTION
in certain situations such as with lots of users, doing "/pex promote a a" will cause the server to hang trying to resolved the username. ensuring they have permission to use the command prevents malicious use of this problem