### PR TITLE
Adding config flag autocompletenames to disable player name autocomplete

### DIFF
--- a/src/main/java/ru/tehkode/permissions/bukkit/PermissionsExConfig.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/PermissionsExConfig.java
@@ -26,6 +26,7 @@ public class PermissionsExConfig {
 	private final boolean updaterEnabled;
 	private final boolean alwaysUpdate;
 	private final boolean informPlayers;
+	private final boolean autocompleteNames;
 	private final List<String> serverTags;
 	private final String basedir;
 
@@ -44,6 +45,7 @@ public class PermissionsExConfig {
 		this.updaterEnabled = getBoolean("updater", true);
 		this.alwaysUpdate = getBoolean("alwaysUpdate", false);
 		this.informPlayers = getBoolean("permissions.informplayers.changes", false);
+		this.autocompleteNames = getBoolean("autocompletenames", true);
 		this.basedir = getString("permissions.basedir", "plugins/PermissionsEx");
 	}
 
@@ -114,6 +116,14 @@ public class PermissionsExConfig {
 
 	public boolean informPlayers() {
 		return informPlayers;
+	}
+
+	public boolean autocompleteNames() {
+		/*
+		 * Used in PermissionsCommand.autoCompletePlayerName to disable user autocomplete.
+		 * Enabled by default to preserve normal behaviour.
+		 */
+		return autocompleteNames;
 	}
 
 	public List<String> getServerTags() {

--- a/src/main/java/ru/tehkode/permissions/bukkit/commands/PermissionsCommand.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/commands/PermissionsCommand.java
@@ -103,7 +103,7 @@ public abstract class PermissionsCommand implements CommandListener {
 		}
 
 		/*
-		 * On large servers searching all user names causes lags/crashes see as
+		 * On large servers searching all user names causes lags/crashes as
 		 * described in issue 2923 and 2987.
 		 */
 		if (!manager.plugin.getConfiguration().autocompleteNames()) {

--- a/src/main/java/ru/tehkode/permissions/bukkit/commands/PermissionsCommand.java
+++ b/src/main/java/ru/tehkode/permissions/bukkit/commands/PermissionsCommand.java
@@ -102,6 +102,14 @@ public abstract class PermissionsCommand implements CommandListener {
 			return nameToUUID(playerName.substring(1));
 		}
 
+		/*
+		 * On large servers searching all user names causes lags/crashes see as
+		 * described in issue 2923 and 2987.
+		 */
+		if (!manager.plugin.getConfiguration().autocompleteNames()) {
+			return playerName;
+		}
+
 		List<String> players = new LinkedList<>();
 
 		// Collect online Player names

--- a/src/main/java/ru/tehkode/permissions/commands/CommandsManager.java
+++ b/src/main/java/ru/tehkode/permissions/commands/CommandsManager.java
@@ -39,7 +39,7 @@ import ru.tehkode.utils.StringUtils;
 public class CommandsManager {
 
 	protected Map<String, Map<CommandSyntax, CommandBinding>> listeners = new LinkedHashMap<>();
-	protected PermissionsEx plugin;
+	public final PermissionsEx plugin;
 
 	public CommandsManager(PermissionsEx plugin) {
 		this.plugin = plugin;


### PR DESCRIPTION
Workaround for issue #2987, #2964 and #2923. Adds config flag autocompletenames to disable user name searching in PermissionsCommand.autoCompletePlayerName.